### PR TITLE
Add support for HMAC-based one time passwords (HOTP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,9 @@ Time-based One Time Password (TOTP) [![GoDoc](https://godoc.org/github.com/zhevr
 go get gopkg.in/zhevron/go2fa.v1/totp
 ```
 
+HMAC-based One Time Password (HOTP) [![GoDoc](https://godoc.org/github.com/zhevron/go2fa/hotp?status.svg)](https://godoc.org/github.com/zhevron/go2fa/hotp)
+```
+go get gopkg.in/zhevron/go2fa.v1/hotp
+```
+
 go2fa is licensed under the [MIT license](http://opensource.org/licenses/MIT).

--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2014 Thomas Lokshall
+// Use of this source code is governed by the MIT license.
+// See LICENSE.md for details.
+
+// Package hotp contains an RFC4226 implementation of HMAC-based one time passwords.
+package hotp
+
+import "github.com/zhevron/go2fa"
+
+// HOTP implements HMAC-based one time passwords as specified in RFC4226 (http://tools.ietf.org/html/rfc4226).
+type HOTP struct {
+	secret   go2fa.Secret
+	length   int
+	duration int
+}
+
+// NewHOTP makes a new HOTP object for generating OTP codes from a given Secret.
+func NewHOTP(s go2fa.Secret) *HOTP {
+	return &HOTP{
+		secret: s,
+	}
+}

--- a/hotp/hotp_test.go
+++ b/hotp/hotp_test.go
@@ -1,0 +1,24 @@
+package hotp
+
+import (
+	"testing"
+
+	"github.com/zhevron/go2fa"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type HOTPSuite struct {
+	secret go2fa.Secret
+	hotp   *HOTP
+}
+
+var _ = Suite(&HOTPSuite{})
+
+func (s *HOTPSuite) SetUpTest(c *C) {
+	s.secret, _ = go2fa.NewSecret(0)
+	s.hotp = NewHOTP(s.secret)
+}


### PR DESCRIPTION
Support should be added for the HOTP algorithm as specified in [RFC4226](http://tools.ietf.org/html/rfc4226)
